### PR TITLE
Add terminalUUID in requests for supporting P105

### DIFF
--- a/PyP100/PyP100.py
+++ b/PyP100/PyP100.py
@@ -178,7 +178,10 @@ class P100():
 
 		EncryptedPayload = self.tpLinkCipher.encrypt(json.dumps(Payload))
 
-		SecurePassthroughPayload = { "method": "securePassthrough", "params":{ "request": EncryptedPayload
+		SecurePassthroughPayload = {
+			"method": "securePassthrough",
+			"params": {
+				"request": EncryptedPayload
 			}
 		}
 

--- a/PyP100/PyP100.py
+++ b/PyP100/PyP100.py
@@ -8,6 +8,7 @@ from Crypto.Cipher import AES, PKCS1_OAEP, PKCS1_v1_5
 from . import tp_link_cipher
 import ast
 import pkgutil
+import uuid
 
 #Old Functions to get device list from tplinkcloud
 def getToken(email, password):
@@ -35,6 +36,7 @@ def getDeviceList(email, password):
 ERROR_CODES = {
 	"0": "Success",
 	"-1010": "Invalid Public Key Length",
+	"-1012": "Invalid terminalUUID",
 	"-1501": "Invalid Request or Credentials",
 	"1002": "Incorrect Request",
 	"-1003": "JSON formatting error "
@@ -43,6 +45,7 @@ ERROR_CODES = {
 class P100():
 	def __init__ (self, ipAddress, email, password):
 		self.ipAddress = ipAddress
+		self.terminalUUID = str(uuid.uuid4())
 
 		self.email = email
 		self.password = password
@@ -98,7 +101,7 @@ class P100():
 				sb += hex_string
 			else:
 				sb += hex_string
-		
+
 		return sb
 
 	def handshake(self):
@@ -118,7 +121,7 @@ class P100():
 
 		try:
 			self.cookie = r.headers["Set-Cookie"][:-13]
-			
+
 		except:
 			errorCode = r.json()["error_code"]
 			errorMessage = self.errorCodes[str(errorCode)]
@@ -166,6 +169,7 @@ class P100():
 				"device_on": True
 			},
 			"requestTimeMils": int(round(time.time() * 1000)),
+			"terminalUUID": self.terminalUUID
 		}
 
 		headers = {
@@ -188,6 +192,7 @@ class P100():
 		if ast.literal_eval(decryptedResponse)["error_code"] != 0:
 			errorCode = ast.literal_eval(decryptedResponse)["error_code"]
 			errorMessage = self.errorCodes[str(errorCode)]
+			raise Exception(f"Error Code: {errorCode}, {errorMessage}")
 
 	def setBrightness(self, brightness):
 		URL = f"http://{self.ipAddress}/app?token={self.token}"
@@ -219,6 +224,7 @@ class P100():
 		if ast.literal_eval(decryptedResponse)["error_code"] != 0:
 			errorCode = ast.literal_eval(decryptedResponse)["error_code"]
 			errorMessage = self.errorCodes[str(errorCode)]
+			raise Exception(f"Error Code: {errorCode}, {errorMessage}")
 
 	def turnOff(self):
 		URL = f"http://{self.ipAddress}/app?token={self.token}"
@@ -228,6 +234,7 @@ class P100():
 				"device_on": False
 			},
 			"requestTimeMils": int(round(time.time() * 1000)),
+			"terminalUUID": self.terminalUUID
 		}
 
 		headers = {
@@ -250,6 +257,7 @@ class P100():
 		if ast.literal_eval(decryptedResponse)["error_code"] != 0:
 			errorCode = ast.literal_eval(decryptedResponse)["error_code"]
 			errorMessage = self.errorCodes[str(errorCode)]
+			raise Exception(f"Error Code: {errorCode}, {errorMessage}")
 
 	def getDeviceInfo(self):
 		URL = f"http://{self.ipAddress}/app?token={self.token}"
@@ -289,6 +297,7 @@ class P100():
 		if data["error_code"] != 0:
 			errorCode = ast.literal_eval(decryptedResponse)["error_code"]
 			errorMessage = self.errorCodes[str(errorCode)]
+			raise Exception(f"Error Code: {errorCode}, {errorMessage}")
 		else:
 			encodedName = data["result"]["nickname"]
 			name = b64decode(encodedName)

--- a/PyP100/PyP100.py
+++ b/PyP100/PyP100.py
@@ -14,13 +14,13 @@ import uuid
 def getToken(email, password):
 	URL = "https://eu-wap.tplinkcloud.com"
 	Payload = {
-	 "method": "login",
-	 "params": {
-	 "appType": "Tapo_Ios",
-	 "cloudUserName": email,
-	 "cloudPassword": password,
-	 "terminalUUID": "0A950402-7224-46EB-A450-7362CDB902A2"
-	 }
+		"method": "login",
+		"params": {
+			"appType": "Tapo_Ios",
+			"cloudUserName": email,
+			"cloudPassword": password,
+			"terminalUUID": "0A950402-7224-46EB-A450-7362CDB902A2"
+		}
 	}
 
 	return requests.post(URL, json=Payload).json()['result']['token']
@@ -28,7 +28,7 @@ def getToken(email, password):
 def getDeviceList(email, password):
 	URL = "https://eu-wap.tplinkcloud.com?token=" + getToken(email, password)
 	Payload = {
-	 "method": "getDeviceList",
+		"method": "getDeviceList",
 	}
 
 	return requests.post(URL, json=Payload).json()
@@ -178,10 +178,7 @@ class P100():
 
 		EncryptedPayload = self.tpLinkCipher.encrypt(json.dumps(Payload))
 
-		SecurePassthroughPayload = {
-			"method": "securePassthrough",
-			"params":{
-				"request": EncryptedPayload
+		SecurePassthroughPayload = { "method": "securePassthrough", "params":{ "request": EncryptedPayload
 			}
 		}
 
@@ -280,9 +277,6 @@ class P100():
 		}
 
 		r = requests.post(URL, json=SecurePassthroughPayload, headers=headers)
-
-
-
 		decryptedResponse = self.tpLinkCipher.decrypt(r.json()["result"]["response"])
 
 		return decryptedResponse


### PR DESCRIPTION
Hello @fishbigger , thank you for everything you have done for this project!

I believe this library supports not only P100, but P105. I realized P105 plug will raise a '-1012' error if there is no `terminalUUID` in the request body of `turnOn` and `turnOff`. Interestingly, other requests (like handshake, login) do not require `terminalUUID`.

```python
>>> p100.login()
>>> info = json.loads(p100.getDeviceInfo())["result"]
>>> {k:v for k,v in info.items() if k in ["fw_ver", "hw_ver", "model"]}
{'fw_ver': '1.3.0 Build 20201201 Rel. 54462', 'hw_ver': '1.0.0', 'model': 'P105'}
>>> p100.turnOff()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/private/tmp/TapoP100/PyP100/PyP100.py", line 253, in turnOff
    errorMessage = self.errorCodes[str(errorCode)]
KeyError: '-1012'
```

I also fixed some exception handling in this commit.