### PR TITLE
Make dependencies more flexible to integrate lib.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ setup_args = dict(
 )
 
 install_requires = [
-    'pycryptodome==3.9.8',
-    'pkcs7==0.1.2',
-    'requests==2.24.0',
+    'pycryptodome>=3.9.8',
+    'pkcs7>=0.1.2',
+    'requests>=2.24.0',
 ]
 
 if __name__ == '__main__':


### PR DESCRIPTION
I found problems integrating on a HomeAssistant were these libs are set to more recent versions. This change will fix that. I've tested with a Tapo switch.