### PR TITLE
Improve parsing of cookie, thus removing trailing ;

### DIFF
--- a/PyP100/PyP100.py
+++ b/PyP100/PyP100.py
@@ -125,7 +125,7 @@ class P100():
 		self.tpLinkCipher = self.decode_handshake_key(encryptedKey)
 
 		try:
-			self.cookie = r.headers["Set-Cookie"][:-13]
+			self.cookie = r.headers["Set-Cookie"].split(";")[0]
 
 		except:
 			errorCode = r.json()["error_code"]

--- a/PyP100/PyP100.py
+++ b/PyP100/PyP100.py
@@ -54,6 +54,7 @@ class P100():
 		self.email = email
 		self.password = password
 		self.session = Session()
+		self.cookie_name = "TP_SESSIONID"
 
 		self.errorCodes = ERROR_CODES
 
@@ -125,7 +126,7 @@ class P100():
 		self.tpLinkCipher = self.decode_handshake_key(encryptedKey)
 
 		try:
-			self.cookie = r.headers["Set-Cookie"].split(";")[0]
+			self.cookie = f"{self.cookie_name}={r.cookies[self.cookie_name]}"
 
 		except:
 			errorCode = r.json()["error_code"]


### PR DESCRIPTION
This PR fixes #76 by correctly passing the correct cookie for `TP_SESSIONID`. A simple error in the code included a trailing semicolon at the end. It is apparent that legacy firmware versions ignored this, but P100 1.1.0 and P110 1.0.16 now treats this as invalid. May also resolve #74