### PR TITLE
Set color temperature to 0 before adjusting color

### DIFF
--- a/PyP100/PyL530.py
+++ b/PyP100/PyL530.py
@@ -72,11 +72,11 @@ class L530(PyP100.P100):
         	errorMessage = self.errorCodes[str(errorCode)]
 
     def setColor(self, hue, saturation):
+        self.setColorTemp(0)
         URL = f"http://{self.ipAddress}/app?token={self.token}"
         Payload = {
         	"method": "set_device_info",
         	"params":{
-        		"color_temp": 0,
         		"hue": hue,
         		"saturation": saturation
         	},

--- a/PyP100/PyL530.py
+++ b/PyP100/PyL530.py
@@ -72,6 +72,7 @@ class L530(PyP100.P100):
         	errorMessage = self.errorCodes[str(errorCode)]
 
     def setColor(self, hue, saturation):
+        self.setColorTemp(0)
         URL = f"http://{self.ipAddress}/app?token={self.token}"
         Payload = {
         	"method": "set_device_info",

--- a/PyP100/PyL530.py
+++ b/PyP100/PyL530.py
@@ -72,11 +72,11 @@ class L530(PyP100.P100):
         	errorMessage = self.errorCodes[str(errorCode)]
 
     def setColor(self, hue, saturation):
-        self.setColorTemp(0)
         URL = f"http://{self.ipAddress}/app?token={self.token}"
         Payload = {
         	"method": "set_device_info",
         	"params":{
+        		"color_temp": 0,
         		"hue": hue,
         		"saturation": saturation
         	},


### PR DESCRIPTION
This fixes #83 by setting the color temperature to zero before trying to adjust the color.