### PR TITLE
Set device status to 'on' when setting color, color temp or brightness

### DIFF
--- a/PyP100/PyL530.py
+++ b/PyP100/PyL530.py
@@ -9,9 +9,9 @@ _LOGGER = logging.getLogger(__name__)
 
 class L530(PyP100.P100):
     def setBrightness(self, brightness):
+        self.turnOn()
         URL = f"http://{self.ipAddress}/app?token={self.token}"
         Payload = {
-        		"device_on": True,
 			"method": "set_device_info",
 			"params":{
 				"brightness": brightness
@@ -42,11 +42,11 @@ class L530(PyP100.P100):
             raise Exception(f"Error Code: {errorCode}, {errorMessage}")
 
     def setColorTemp(self, colortemp):
+        self.turnOn()
         URL = f"http://{self.ipAddress}/app?token={self.token}"
         Payload = {
         	"method": "set_device_info",
         	"params":{
-        		"device_on": True,
         		"color_temp": colortemp
         	},
         	"requestTimeMils": int(round(time.time() * 1000)),
@@ -74,11 +74,11 @@ class L530(PyP100.P100):
         	errorMessage = self.errorCodes[str(errorCode)]
 
     def setColor(self, hue, saturation):
+        self.turnOn()
         URL = f"http://{self.ipAddress}/app?token={self.token}"
         Payload = {
         	"method": "set_device_info",
         	"params":{
-        		"device_on": True,
         		"hue": hue,
         		"saturation": saturation
         	},

--- a/PyP100/PyL530.py
+++ b/PyP100/PyL530.py
@@ -44,9 +44,9 @@ class L530(PyP100.P100):
     def setColorTemp(self, colortemp):
         URL = f"http://{self.ipAddress}/app?token={self.token}"
         Payload = {
-       		"device_on": True,
         	"method": "set_device_info",
         	"params":{
+        		"device_on": True,
         		"color_temp": colortemp
         	},
         	"requestTimeMils": int(round(time.time() * 1000)),

--- a/PyP100/PyL530.py
+++ b/PyP100/PyL530.py
@@ -11,6 +11,7 @@ class L530(PyP100.P100):
     def setBrightness(self, brightness):
         URL = f"http://{self.ipAddress}/app?token={self.token}"
         Payload = {
+        		"device_on": True,
 			"method": "set_device_info",
 			"params":{
 				"brightness": brightness
@@ -43,6 +44,7 @@ class L530(PyP100.P100):
     def setColorTemp(self, colortemp):
         URL = f"http://{self.ipAddress}/app?token={self.token}"
         Payload = {
+       		"device_on": True,
         	"method": "set_device_info",
         	"params":{
         		"color_temp": colortemp
@@ -76,6 +78,7 @@ class L530(PyP100.P100):
         Payload = {
         	"method": "set_device_info",
         	"params":{
+        		"device_on": True,
         		"hue": hue,
         		"saturation": saturation
         	},


### PR DESCRIPTION
If one turns on the L530 bulb by using `setBrightness()`, `setColor()` or `setColorTemp()` calls, the device info still says the lamp is turned off. This means that the call to `turnOff()` doesn't work without `turnOn()` has been called.

This PR fixes this issue by adding the device status to the payload of these three calls.