### PR TITLE
Convert brightness to float

### DIFF
--- a/PyP100/PyL530.py
+++ b/PyP100/PyL530.py
@@ -14,7 +14,7 @@ class L530(PyP100.P100):
         Payload = {
 			"method": "set_device_info",
 			"params":{
-				"brightness": brightness
+				"brightness": float(brightness)
 			},
 			"requestTimeMils": 0,
 		}


### PR DESCRIPTION
Single digit integer inputs (values 1 to 9) raise an error. Converting the brightness to float solves this issue.